### PR TITLE
updating graphql fields for street number and name

### DIFF
--- a/src/components/details.js
+++ b/src/components/details.js
@@ -16,7 +16,7 @@ export default ({props}) => {
               <ul>
                 <li><strong>Gender:</strong> {props.gender}</li>
                 <li><strong>Email:</strong> {props.email}</li>
-                <li><strong>Address:</strong> {props.location.street}, {props.location.city}, {props.location.state}</li>
+                <li><strong>Address:</strong> {props.location.street.name} {props.location.street.name}, {props.location.city}, {props.location.state}</li>
               </ul>
             </div>
           </div>

--- a/src/components/details.js
+++ b/src/components/details.js
@@ -16,7 +16,7 @@ export default ({props}) => {
               <ul>
                 <li><strong>Gender:</strong> {props.gender}</li>
                 <li><strong>Email:</strong> {props.email}</li>
-                <li><strong>Address:</strong> {props.location.street.name} {props.location.street.name}, {props.location.city}, {props.location.state}</li>
+                <li><strong>Address:</strong> {props.location.street.number} {props.location.street.name}, {props.location.city}, {props.location.state}</li>
               </ul>
             </div>
           </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,7 +35,7 @@ export const query = graphql`
             thumbnail
           }
           location {
-            street
+            street{number name}
             city
             state
           }


### PR DESCRIPTION
Looks like the API may have split out street number and street name. 

While this works in gatsby develop I'm still getting a webpack error on production builds that I haven't yet figured out.

  WebpackError: TypeError: Cannot read property 'props' of undefined
  
  - details.js:5 ./src/pages/details.js.__webpack_exports__.default
    src/pages/details.js:5:30